### PR TITLE
Add 'draft' command to create draft.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,28 @@ So the basic skeleton of a `github_release_manager.sh` command is as follows:
 * (3): a release tag
 * (4): xxx: a command to execute
 
+**Use case 0: create release-draft called "v2.3.1" on "plast-java-app" owned by "PLAST-software"**
+
+Sometimes you need to build up a release, including adding files, before you publish the release.
+This is necessary for tools like Zenodo that only consider the state of a release at the time that
+it is published.  The workflow is to create a draft, add files, maybe modify notes, and publish
+(via the release editor on GitHub).
+
+For this first step, we use the "draft" command (rather than "create"):
+
+        github_release_manager.sh \
+            -l pgdurand -t 268ujk \
+            -o PLAST-software -r plast-java-app \
+            -d v2.3.1 \
+            -c draft
+
+Note the tag in the output, e.g.,
+```
+  tag is: untagged-86bca6e7cbe1f28c2596e
+```
+To modify this release, you will need to use 'untagged-86bca6e7cbe1f28c2596' for
+the `-d` argument value in lieu of 'v2.3.1' for the other use cases below.
+
 **Use case 1: create release called "v2.3.1" on "plast-java-app" owned by "PLAST-software"**
 
 For that, we use the "create" command:
@@ -155,7 +177,15 @@ For that, we use the "info" command, as follows:
             -o PLAST-software -r plast-java-app \
             -d v2.3.1 \
             -c info
-  
+
+To make this easier-to-read YAML, assuming that you have sed and json2yaml installed
+
+        github_release_manager.sh \
+            -l pgdurand -t 268ujk \
+            -o PLAST-software -r plast-java-app \
+            -d v2.3.1 \
+            -c info | sed -n -e '1 d; p' | json2yaml -
+
 **Use case 6: delete a file from a particular project release**
 
 For that, we use the "delete" command and pass in the name of the file to delete from the release, as follows:

--- a/README.md
+++ b/README.md
@@ -215,7 +215,13 @@ For that, we use the "erase" command and pass in the file, as follows:
 	  -s turn script to silent mode
 	  -m release message: only used when creating a new release
 	  -h display this message
-	
+
+# Release notes
+
+- v1.1.0 (eschen42)
+  - added 'draft' command
+- v1.0.0 (pdurand)
+  - released Patrick Durand's code as forked from https://github.com/pgdurand/github-release-api
 # License
 
 This project includes a slightly modified version of [JSON.sh](https://github.com/dominictarr/JSON.sh) which is covered by MIT and Apache V2 licenses.

--- a/github_release_api.sh
+++ b/github_release_api.sh
@@ -374,6 +374,14 @@ END
     dField=$(getDataField "$github_answer" "message")
 	  throw "  Failed. $dField"
   fi
+  # show tag, which is needed to access a draft release
+  tagField=$(getDataField "$github_answer" "html_url")
+  if [ ! -z "$tagField" ]; then
+    infoMsg "  tag is: $(echo $tagField | sed -e 's@.*/@@')"
+  else
+    msgField=$(getDataField "$github_answer" "message")
+	  throw "  Failed. $msgField"
+  fi
 }
 
 # --------

--- a/github_release_api.sh
+++ b/github_release_api.sh
@@ -416,7 +416,7 @@ function checkMandatoryArg(){
 #  return: nothing
 #   throw: exit application if value is unknown
 function checkCommand(){
-  local cmds=( "create" "flist" "rlist" "upload" "delete" "info" "erase")
+  local cmds=( "create" "draft" "flist" "rlist" "upload" "delete" "info" "erase")
   
   if [[ "${cmds[*]}" =~ "$1" ]]; then
     return 0

--- a/github_release_api.sh
+++ b/github_release_api.sh
@@ -44,7 +44,7 @@ TAG=""
 #list of files from command-line ([file ...] part if any)
 FILES=""
 #default message used to create a new release
-CREATE_MESSAGE="new release"
+CREATE_MESSAGE="new draft release"
 #by default this script talk to you
 SILENT="off"
 
@@ -329,12 +329,14 @@ END
 # --------
 # FUNCTION: upload a file to github
 #   arg1: tag name
-#   arg2: release description (optional)
+#   arg2: create draft release? "true" or "false" (optional, defaults is "true")
+#   arg3: release description (optional)
 #   return: nothing
 #   throw: exit if tag already exist as a release on github side, or if release 
 #          creation failed.
 function createRelease(){
-  local release_desc="new release"
+  local release_desc="$CREATE_MESSAGE"
+  local draft="true"
   local dField=""
   # Connect github to create release
   infoMsg "Connecting github to create release: $1"
@@ -353,7 +355,7 @@ function createRelease(){
  "target_commitish": "master",
  "name": "$1",
  "body": "$release_desc",
- "draft": false,
+ "draft": $draft,
  "prerelease": false
 }
 END

--- a/github_release_api.sh
+++ b/github_release_api.sh
@@ -336,7 +336,13 @@ END
 #          creation failed.
 function createRelease(){
   local release_desc="$CREATE_MESSAGE"
+  if [ ! -z "$3" ]; then
+    release_desc="$3"
+  fi
   local draft="true"
+  if [ ! -z "$2" ]; then
+    draft="$2"
+  fi
   local dField=""
   # Connect github to create release
   infoMsg "Connecting github to create release: $1"
@@ -344,6 +350,16 @@ function createRelease(){
   if [ $# -eq 2 ]; then
     release_desc=$2 
   fi
+  cat <<END
+{
+ "tag_name": "$1",
+ "target_commitish": "master",
+ "name": "$1",
+ "body": "$release_desc",
+ "draft": $draft,
+ "prerelease": false
+}
+END
   curl --user ${LOGIN}:${TOKEN} \
      --request POST \
      --output "$github_answer" \

--- a/github_release_manager.sh
+++ b/github_release_manager.sh
@@ -23,8 +23,12 @@
 # This script can be used either as a command-line tool (use -h to get help) or as an API.
 # For the latter use, see github_release_api.sh script.
 #
-# Author: Patrick Durand, Inria
+# Author: Patrick Durand, Inria (pdurand)
 # Created: December 2015
+#
+# ---
+# Updated: Art Eschenlauer, University of Minnesota (eschen42)
+# Change:  Added "draft" command
 #*****************************************************************************************
 
 # ========================================================================================
@@ -47,8 +51,9 @@ function help(){
   printf "\n"
   printf "Release managment commands are provided using:\n"
   printf "  -c <command> command to execute.\n"
-  printf "   'command' is one of create, list, upload, delete, info.\n"
+  printf "   'command' is one of create, draft, flist, upload, delete, info, erase, rlist.\n"
   printf "   create: create a new release.\n"
+  printf "    draft: create a new draft release.\n"
   printf "    flist: list files available for an existing release.\n"
   printf "   upload: upload file(s) to an existing release.\n"
   printf "   delete: permanently delete remote file(s) from an existing release.\n"
@@ -114,7 +119,11 @@ case "$COMMAND" in
     ;;
   create)
     checkTag
-    createRelease $TAG "$CREATE_MESSAGE"
+    createRelease $TAG "false" "$CREATE_MESSAGE"
+    ;;
+  draft)
+    checkTag
+    createRelease $TAG "true" "$CREATE_MESSAGE"
     ;;
   upload) 
     checkTag


### PR DESCRIPTION
Sometimes you need to build up a release, including adding files, before you publish the release.
This is necessary for tools like Zenodo that only consider the state of a release at the time that
it is published.  The workflow is to create a draft, add files, maybe modify notes, and publish
(via the release editor on GitHub).

Therefore, I added the "draft" command.   Please let me know what you think of these changes.  Thank you.