### PR TITLE
Fix api requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # About 
 
+(A fork of the upstram repository because it turns out to not work with the current GitHub API)
+
 This package contains utility scripts to manage:
 
 * git tags: add and delete tags using (1) a canonical format and (2) some controls

--- a/github_release_api.sh
+++ b/github_release_api.sh
@@ -353,7 +353,6 @@ function createRelease(){
   cat <<END
 {
  "tag_name": "$1",
- "target_commitish": "master",
  "name": "$1",
  "body": "$release_desc",
  "draft": $draft,
@@ -368,7 +367,6 @@ END
      https://api.github.com/repos/${OWNER}/${REPOSITORY}/releases <<END
 {
  "tag_name": "$1",
- "target_commitish": "master",
  "name": "$1",
  "body": "$release_desc",
  "draft": $draft,


### PR DESCRIPTION
The current GitHub API (contrary to its doc) checks the target_commitish in requests and rejects all requests where it is invalid. Since it isn't used or required when a tag is specified, and we always specify a tag, this PR removes it.